### PR TITLE
Alternative syntax to register services

### DIFF
--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -1,65 +1,83 @@
 module Twirp
+
   class Service
-    @@rpcs = {}
 
-    def initialize(svc)
-      @svc = svc
+    def initialize(attrs)
+      # TODO: validate inputs (report good error messages if not properly initialized)
+      @service_name = attrs[:service_name]
+      @package = attrs[:package]
+      @rpc_types = attrs[:rpc_types] # classes to serialize request and responses for each rpc. TODO: ensure keys are Strings, etc.
+
+      @rpc_handlers = {} # handlers for each rpc
     end
 
-    def self.rpc(name, request_class, response_class)
-      @@rpcs[name] = {
-        request_class: request_class,
-        response_class: response_class
-      }
+    # Register an rpc handler.
+    def rpc(method_name, &block)
+      # TODO: validate method_name (included in @rpc_types?) and block (arity), report good error messages
+      @rpc_handlers[method_name.to_s] = block
     end
 
-    def route_request(req)
-      # Parse url to get method names
-      method_name = req.fullpath[self.class::PATH_PREFIX.length+1..-1]
+    # Register a before hook.
+    def before(&block)
+      # TODO... and also after hooks
+    end
 
-      # Get req/res types from @@rpcs
-      rpc = @@rpcs[method_name.to_sym]
-      request_class = rpc[:request_class]
-      response_class = rpc[:response_class]
+    def path_prefix
+      "/twirp/@{@package}.#{@service_name}"
+    end
 
-      case req.env["CONTENT_TYPE"]
+    def route_request(http_req)
+      # Parse request
+      method_name = http_req.fullpath[path_prefix.length+1..-1]
+      rpc_type = @rpc_types[method_name]
+      request_class = 
+      response_class = rpc_type[:response_class]
+      content_type = http_req.env["CONTENT_TYPE"] # TODO: validate
+
+      params = decode_request(rpc_type[:request_class], content_type, http_req.body.read)
+
+      # Handle request
+      handler = @rpc_handlers[method_name]
+      resp = handler.call(params) # TODO: add begin-resque to hadnle exceptions
+
+      # Error responses
+      if resp.is_a? Twirp::Error
+        status = Twirp::ERROR_CODES_TO_HTTP_STATUS[resp.code]
+        return [status, {'Content-Type' => 'application/json'}, [resp.to_json]]
+      end
+
+      # Encode response
+      if resp.is_a? Hash # allow handlers to respond with just the attributes
+        resp = response_class.new(resp)
+      end
+      encoded_resp = encode_response(response_class, content_type, resp)
+
+      return ['200', {'Content-Type' => content_type}, [encoded_resp]]
+    end
+
+    def decode_request(request_class, content_type, body)
+      case content_type
       when "application/json"
-        return self.serve_json(req, method_name, request_class, response_class)
+        request_class.decode_json(body)
       when "application/protobuf"
-        return self.serve_proto(req, method_name, request_class, response_class)
-      else
-        return self.serve_error(Twerr.NotFound("unexpected Content-Type: #{req.env["CONTENT_TYPE"]}"))
+        request_type.decode(body)
       end
     end
 
-    def serve_json(req, method_name, request_class, response_class)
-      params = request_class.decode_json(req.body.read)
-      resp = @svc.send(method_name, params)
-      self.serve_success_json(response_class.encode_json(resp))
+    def encode_response(response_class, content_type, resp)
+      case content_type
+      when "application/json"
+        response_class.encode_json(resp)
+      when "application/protobuf"
+        response_class.encode(resp)
+      end
     end
 
-    def serve_proto(req, method_name, request_class, response_class)
-      params = request_type.decode(req.body.read)
-      resp = @svc.send(method_name, params)
-      self.serve_success_proto(response_class.encode(resp))
-    end
-
-    def serve_success_proto(resp)
-      return ['200', {'Content-Type' => 'application/protobuf'}, [resp]]
-    end
-
-    def serve_success_json(resp)
-      return ['200', {'Content-Type' => 'application/json'}, [resp]]
-    end
-
-    def serve_error(twerr)
-      return ['500', {'Content-Type' => 'application/json'}, []]
-    end
-
-    def handler
+    # Return a proc that can be mounter as a Rack app to serve HTTP traffic
+    def rack_handler
       return Proc.new do |env|
         req = Rack::Request.new(env)
-        self.route_request(req)
+        route_request(req)
       end
     end
   end

--- a/lib/twirp/service_registry.rb
+++ b/lib/twirp/service_registry.rb
@@ -1,0 +1,20 @@
+module Twirp
+
+  # Register a new service
+  def self.[]=(key, value)
+    @@services ||= {}
+    @@services[key] = value
+  end
+
+  # Access a registered service
+  def self.[](key)
+    return nil unless @@services
+    @@services[key]
+  end
+
+  # Clear all registered services
+  def self.clear_services!
+    @@services = nil
+  end
+
+end

--- a/test/service_registry_test.rb
+++ b/test/service_registry_test.rb
@@ -1,0 +1,29 @@
+require 'minitest/autorun'
+
+require_relative '../lib/twirp/service_registry'
+
+# This is testing Twirp.register_service internals, to make sure it works as expected.
+class TestRegisterService < Minitest::Test
+  def setup
+    Twirp.clear_services! # make sure the registry is clean
+  end
+
+  def test_register_valid_service
+    Twirp["foopkg.FooService"] = fake_service
+    assert_equal fake_service, Twirp["foopkg.FooService"]
+  end
+
+  def test_clear_services
+    Twirp["foopkg.FooService"] = fake_service
+    Twirp.clear_services!
+    assert_nil Twirp["foopkg.FooService"]
+  end
+
+
+private
+
+  def fake_service
+    "fake" # service type not validate at this moment
+  end
+
+end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -1,0 +1,42 @@
+require 'minitest/autorun'
+
+require 'google/protobuf'
+require_relative '../lib/twirp'
+
+# Define the proto messages (this what the protoc generator would produce)
+Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "foopkg.DoFooRequest" do
+    optional :foo, :string, 1
+  end
+  add_message "foopkg.DoFooResponse" do
+    optional :bar, :string, 1
+  end
+end
+module FooPkg
+  DoFooRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("foopkg.DoFooRequest").msgclass
+  DoFooResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("foopkg.DoFooResponse").msgclass
+end
+
+class ServiceTest < Minitest::Test
+  def test_new_valid_service
+
+    svc = Twirp::Service.new({
+      package: "foopkg",
+      service_name: "Foo",
+      rpc_types: {
+        DoFoo: {
+          request_class: FooPkg::DoFooRequest,
+          response_class: FooPkg::DoFooResponse,
+        }
+      }
+    })
+    
+    svc.rpc "DoFoo" do |req|
+      return {bar: "Hello #{req.foo}"}
+    end
+
+    svc.rack_handler
+  end
+
+  # TODO send fake HTTP requests, check responses
+end


### PR DESCRIPTION
This PR is just to explore an alternative syntax.

Autogenerated Twirp code:
```ruby
Twirp["foopkg.Foo"] = Twirp::Service.new({
  package: "foopkg",
  service_name: "Foo",
  rpc_types: {
    DoFoo: {
      request_class: FooPkg::DoFooRequest,
      response_class: FooPkg::DoFooResponse,
    }
  }
})
```

Define method handlers:
```ruby
Twirp["foopkg.Foo"].rpc "DoFoo" do |req|
  return {bar: "Hello #{req.foo}"}
end
```

Initialize server:
```ruby
Rack::Handler::WEBrick.run Twirp["foopkg.Foo"].rack_handler
```