### PR TITLE
Service implementation

### DIFF
--- a/lib/twirp/error.rb
+++ b/lib/twirp/error.rb
@@ -41,7 +41,23 @@ module Twirp
 
     attr_reader :code
     attr_reader :msg
-    def meta; @meta || {}; end
+    
+    def meta(key)
+      @meta ||= {}
+      @meta[key]
+    end
+
+    def add_meta(key, value)
+      validate_meta_key_value(key, value)
+      @meta ||= {}
+      @meta[key] = value
+    end
+
+    def delete_meta(key)
+      @meta ||= {}
+      @meta.delete(key.to_s)
+      @meta = nil if @meta.size == 0
+    end
 
     def as_json
       h = {
@@ -73,12 +89,16 @@ module Twirp
       if !meta.is_a? Hash
         raise ArgumentError.new("Twirp::Error meta must be a Hash, but it is a #{meta.class.to_s}")
       end
-      meta.each do |k, v|
-        if !k.is_a?(String) || !v.is_a?(String)
-          raise ArgumentError.new("Twirp::Error meta must be a Hash with String keys and values")
-        end
+      meta.each do |key, value| 
+        validate_meta_key_value(key, value)        
       end
       meta
+    end
+
+    def validate_meta_key_value(key, value)
+      if !key.is_a?(String) || !value.is_a?(String)
+        raise ArgumentError.new("Twirp::Error meta must be a Hash with String keys and values")
+      end
     end
 
   end

--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -1,66 +1,114 @@
 module Twirp
+
   class Service
-    @@rpcs = {}
 
-    def initialize(svc)
-      @svc = svc
-    end
+    # Configure service routing to handle rpc calls.
+    def self.rpc(method_name, request_class, response_class, opts)
+      if !request_class.is_a?(Class)
+        raise ArgumentError.new("request_class must be a Protobuf Message class")
+      end 
+      if !response_class.is_a?(Class)
+        raise ArgumentError.new("response_class must be a Protobuf Message class")
+      end
+      if !opts || !opts[:handler_method]
+        raise ArgumentError.new("opts[:handler_method] is mandatory")
+      end
 
-    def self.rpc(name, request_class, response_class)
-      @@rpcs[name] = {
+      @rpcs ||= {}
+      @rpcs[method_name.to_s] = {
         request_class: request_class,
-        response_class: response_class
+        response_class: response_class,
+        handler_method: opts[:handler_method],
       }
     end
 
-    def route_request(req)
-      # Parse url to get method names
-      method_name = req.fullpath[self.class::PATH_PREFIX.length+1..-1]
+    def self.rpcs
+      @rpcs || {}
+    end
 
-      # Get req/res types from @@rpcs
-      rpc = @@rpcs[method_name.to_sym]
-      request_class = rpc[:request_class]
-      response_class = rpc[:response_class]
+    # Instantiate a new service with a handler.
+    # A handler implements each rpc method as a regular object method call.
+    def initialize(handler)
+      @handler = handler # TODO: validate that handler responds to all expected methods (report good error message if not)
+    end
 
-      case req.env["CONTENT_TYPE"]
+    # Register a before hook (not implemented)
+    def before(&block)
+      # TODO... and also after hooks
+    end
+
+    # A service instance is a Rack middleware block.
+    def call(env)
+      req = Rack::Request.new(env)
+
+      if req.request_method != "POST"
+        return error_response(bad_route_error("Only POST method is allowed", req))
+      end
+      
+      method_name = req.fullpath.split("/").last
+      rpc_method = self.class.rpcs[method_name]
+      if !rpc_method
+        return error_response(bad_route_error("rpc method not found: #{method_name.inspect}", req))
+      end
+
+      request_class = rpc_method[:request_class]
+      response_class = rpc_method[:response_class]
+
+      content_type = req.env["CONTENT_TYPE"]
+      req_msg = decode_request(rpc_method[:request_class], content_type, req.body.read)
+      if !req_msg
+        return error_response(bad_route_error("unexpected Content-Type: #{content_type.inspect}", req))
+      end
+
+      # Handle Twirp request
+      # TODO: wrap with begin-rescue block
+      resp_msg = @handler.send(rpc_method[:handler_method], req_msg)
+
+      if resp_msg.is_a? Twirp::Error
+        return error_response(resp_msg)
+      end
+
+      if resp_msg.is_a? Hash # allow handlers to respond with just the attributes
+        resp_msg = response_class.new(resp_msg)
+      end
+      encoded_resp = encode_response(response_class, content_type, resp_msg)
+
+      return [200, {'Content-Type' => content_type}, [encoded_resp]]
+
+      # TODO: add recue for any error in the method, wrap with Twith error
+    end
+
+  private
+
+    def decode_request(request_class, content_type, body)
+      case content_type
       when "application/json"
-        return self.serve_json(req, method_name, request_class, response_class)
+        request_class.decode_json(body)
       when "application/protobuf"
-        return self.serve_proto(req, method_name, request_class, response_class)
-      else
-        return self.serve_error(Twerr.NotFound("unexpected Content-Type: #{req.env["CONTENT_TYPE"]}"))
+        request_type.decode(body)
       end
     end
 
-    def serve_json(req, method_name, request_class, response_class)
-      params = request_class.decode_json(req.body.read)
-      resp = @svc.send(method_name, params)
-      self.serve_success_json(response_class.encode_json(resp))
-    end
-
-    def serve_proto(req, method_name, request_class, response_class)
-      params = request_type.decode(req.body.read)
-      resp = @svc.send(method_name, params)
-      self.serve_success_proto(response_class.encode(resp))
-    end
-
-    def serve_success_proto(resp)
-      return ['200', {'Content-Type' => 'application/protobuf'}, [resp]]
-    end
-
-    def serve_success_json(resp)
-      return ['200', {'Content-Type' => 'application/json'}, [resp]]
-    end
-
-    def serve_error(twerr)
-      return ['500', {'Content-Type' => 'application/json'}, []]
-    end
-
-    def handler
-      return Proc.new do |env|
-        req = Rack::Request.new(env)
-        self.route_request(req)
+    def encode_response(response_class, content_type, resp)
+      case content_type
+      when "application/json"
+        response_class.encode_json(resp)
+      when "application/protobuf"
+        response_class.encode(resp)
       end
     end
+
+    def error_response(twirp_error)
+      status = Twirp::ERROR_CODES_TO_HTTP_STATUS[twirp_error.code]
+      headers = {'Content-Type' => 'application/json'} 
+      resp_body = twirp_error.to_json
+      [status, headers, [resp_body]]
+    end
+
+    def bad_route_error(msg, req)
+      meta_invalid_route = "#{req.request_method} #{req.fullpath}"
+      Twirp::Error.new(:bad_route, msg, "twirp_invalid_route" => meta_invalid_route)
+    end
+
   end
 end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -1,0 +1,50 @@
+require 'minitest/autorun'
+
+require 'google/protobuf'
+require_relative '../lib/twirp'
+
+# Define the proto messages (this what the protoc generator would produce)
+Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "foopkg.DoFooRequest" do
+    optional :foo, :string, 1
+  end
+  add_message "foopkg.DoFooResponse" do
+    optional :bar, :string, 1
+  end
+end
+module FooPkg
+  DoFooRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("foopkg.DoFooRequest").msgclass
+  DoFooResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("foopkg.DoFooResponse").msgclass
+end
+
+module FooPkg
+  class FooService < Twirp::Service
+    rpc "DoFoo", DoFooRequest, DoFooResponse, handler_method: :do_foo
+  end
+end
+
+class FooHandler
+  def do_foo(req)
+    {bar: "Hello #{req.foo}"}
+  end
+end
+
+class ServiceTest < Minitest::Test
+
+  def test_rpc_methods
+    assert_equal 1, FooPkg::FooService.rpcs.size
+    assert_equal({
+      request_class: FooPkg::DoFooRequest,
+      response_class: FooPkg::DoFooResponse,
+      handler_method: :do_foo,
+    }, FooPkg::FooService.rpcs["DoFoo"])
+  end
+  
+  def test_initialize_service
+    svc = FooPkg::FooService.new(FooHandler.new)
+    assert svc.respond_to?(:call)
+  end
+
+  # TODO test invalid configurations
+  # TODO test fake HTTP requests, check responses ...
+end


### PR DESCRIPTION
Revisit Twirp::Service implementation
 * Add a few validations.
 * Error responses for bad_route: invalid HTTP method, invalid rpc method and invalid Content-Type.
 * Simplify Rack handler: the Service instance implements `call` which makes it a Proc that can be used itself as Rack middleware (no need for `.rack_handler` method).
 * Handle Twirp::Error responses
 * Handle Hash attributes to build the response object (no need to explicitly mention the response class in the handler)
 * Rename "impl" to "handler".
 * Add basic service test
 * Fix issue with `@@class_vars` when defining multiple services (`@@rpcs = {}` would be shared across every class that inherits from Twirp::Service, essentially it is a global).