### PR TITLE
Fix routing bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    twirp (0.1.0)
-      faraday
-      google-protobuf (>= 3.0.0)
+    twirp (0.5.1)
+      faraday (~> 0)
+      google-protobuf (~> 3.0, >= 3.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -17,8 +17,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 1)
+  bundler (~> 1)
   twirp!
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/lib/twirp/client.rb
+++ b/lib/twirp/client.rb
@@ -97,7 +97,7 @@ module Twirp
       end
 
       def rpc_path(service_full_name, rpc_method)
-        "/#{service_full_name}/#{rpc_method}"
+        "/twirp/#{service_full_name}/#{rpc_method}"
       end
 
     end # class << self

--- a/lib/twirp/client.rb
+++ b/lib/twirp/client.rb
@@ -135,7 +135,7 @@ module Twirp
       body = Encoding.encode(input, rpcdef[:input_class], @content_type)
 
       resp = @conn.post do |r|
-        r.url "/#{@service_full_name}/#{rpc_method}"
+        r.url Client.rpc_path(@service_full_name, rpc_method)
         r.headers['Content-Type'] = @content_type
         r.headers['Accept'] = @content_type
         r.body = body

--- a/lib/twirp/version.rb
+++ b/lib/twirp/version.rb
@@ -1,3 +1,3 @@
 module Twirp
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -12,6 +12,12 @@ class ClientTest < Minitest::Test
     Twirp::Client.rpc_path(service, rpc)
   end
 
+  def test_rpc_path
+    service_name = 'Foo'
+    rpc_name = 'Bar'
+    assert_equal Twirp::Client.rpc_path(service_name, rpc_name), '/twirp/Foo/Bar'
+  end
+
   def test_new_empty_client
     c = EmptyClient.new("http://localhost:8080")
     refute_nil c

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -7,8 +7,8 @@ require 'twirp/version'
 Gem::Specification.new do |spec|
   spec.name          = "twirp"
   spec.version       = Twirp::VERSION
-  spec.authors       = ["Cyrus A. Forbes", "Mario Izquierdo"]
-  spec.email         = ["forbescyrus@gmail.com", "tothemario@gmail.com"]
+  spec.authors       = ["Cyrus A. Forbes", "Mario Izquierdo", "Kyle Montag"]
+  spec.email         = ["forbescyrus@gmail.com", "tothemario@gmail.com", "thekylemontag@gmail.com"]
   spec.summary       = %q{Twirp services in Ruby.}
   spec.description   = %q{Twirp is a simple RPC framework with protobuf service definitions. The Twirp gem provides native support for Ruby.}
   spec.homepage      = "https://github.com/cyrusaf/ruby-twirp"


### PR DESCRIPTION
updated this gem to produce a client that will call the correct path based on the Twirp 5 routing spec.

Namely, the RPC paths were not being prefixed with `/twirp` which was causing errors.

It turned out the method on the client `rpc_path` wasn't being called anywhere, so I changed that and updated the tests accordingly.

Let me know if there is anything else you would like me to change.

<3 Kyle