### PR TITLE
Fix base url

### DIFF
--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ..
   specs:
-    twirp (0.1.0)
-      faraday
-      google-protobuf (>= 3.0.0)
+    twirp (0.5.0)
+      faraday (~> 0)
+      google-protobuf (~> 3.0, >= 3.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/example/hello_world_client.rb
+++ b/example/hello_world_client.rb
@@ -3,7 +3,7 @@ require_relative 'hello_world/service_pb.rb'
 require_relative 'hello_world/service_twirp.rb'
 
 # Assume hello_world_server is running locally
-c = Example::HelloWorldClient.new("http://localhost:8080")
+c = Example::HelloWorldClient.new("http://localhost:8080/twirp")
 
 resp = c.hello(name: "World")
 if resp.error

--- a/example/hello_world_server.rb
+++ b/example/hello_world_server.rb
@@ -1,7 +1,10 @@
 require 'rack'
+require 'webrick'
+
 require_relative 'hello_world/service_pb.rb'
 require_relative 'hello_world/service_twirp.rb'
 
+# Service implementation
 class HelloWorldHandler
   def hello(req, env)
     puts ">> Hello #{req.name}"
@@ -9,7 +12,13 @@ class HelloWorldHandler
   end
 end
 
+# Instantiate Service
 handler = HelloWorldHandler.new()
 service = Example::HelloWorldService.new(handler)
 
-Rack::Handler::WEBrick.run service
+
+# Mount on webserver
+path_prefix = "/twirp/" + service.full_name
+server = WEBrick::HTTPServer.new(Port: 8080)
+server.mount path_prefix, Rack::Handler::WEBrick, service
+server.start

--- a/lib/twirp/client_json.rb
+++ b/lib/twirp/client_json.rb
@@ -20,13 +20,7 @@ module Twirp
     def rpc(rpc_method, attrs={})
       body = Encoding.encode_json(attrs)
 
-      resp = @conn.post do |r|
-        r.url "/#{@service_full_name}/#{rpc_method}"
-        r.headers['Content-Type'] = Encoding::JSON
-        r.headers['Accept'] = Encoding::JSON
-        r.body = body
-      end
-
+      resp = self.class.make_http_request(@conn, @service_full_name, rpc_method, Encoding::JSON, body)
       if resp.status != 200
         return ClientResp.new(nil, self.class.error_from_response(resp))
       end

--- a/lib/twirp/version.rb
+++ b/lib/twirp/version.rb
@@ -1,3 +1,3 @@
 module Twirp
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
Using a base_url with a path prefix was not working as expected: the path prefix was being ignored. This was reported in this PR: https://github.com/cyrusaf/ruby-twirp/pull/8, but the problem was a missunderstanding of the twirp protocol v6 (still unpublished) and also a bug in the code that was preventing the right behavior.

The issue is that the client was using url: `"/#{service_full_name}/..."` (with a leading slash), which for Faraday means to use an absolute URL, thus ignoring the prefix (see issue https://github.com/lostisland/faraday/issues/293).

The fix was just to remove the leading slash in the url: `"#{service_full_name}/..." to make it a relative path, thus respecting the path prefix.

In addition, the example app and README were changed to represent the common case of using a `/twirp` prefix in the URL.