### PR TITLE
Add license headers to all lib files

### DIFF
--- a/lib/twirp.rb
+++ b/lib/twirp.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 require_relative 'twirp/version'
 require_relative 'twirp/error'
 require_relative 'twirp/service'

--- a/lib/twirp/client.rb
+++ b/lib/twirp/client.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 require 'faraday'
 
 require_relative 'client_resp'

--- a/lib/twirp/client_json.rb
+++ b/lib/twirp/client_json.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 require_relative 'client'
 
 module Twirp

--- a/lib/twirp/client_resp.rb
+++ b/lib/twirp/client_resp.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 module Twirp
   class ClientResp
     attr_accessor :data

--- a/lib/twirp/encoding.rb
+++ b/lib/twirp/encoding.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 require 'json'
 
 module Twirp

--- a/lib/twirp/error.rb
+++ b/lib/twirp/error.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 module Twirp
 
   # Valid Twirp error codes and their mapping to related HTTP status.

--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 require_relative 'encoding'
 require_relative 'error'
 require_relative 'service_dsl'

--- a/lib/twirp/service_dsl.rb
+++ b/lib/twirp/service_dsl.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 module Twirp
 
   module ServiceDSL

--- a/lib/twirp/version.rb
+++ b/lib/twirp/version.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 module Twirp
   VERSION = "0.5.2"
 end

--- a/protoc-gen-twirp_ruby/main.go
+++ b/protoc-gen-twirp_ruby/main.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the License is
+// located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package main
 
 import (

--- a/test/license_header_test.rb
+++ b/test/license_header_test.rb
@@ -1,0 +1,37 @@
+require 'minitest/autorun'
+
+# Check that all .rb files in /lib have the license header.
+class LicenseHeaderTest < Minitest::Test
+
+  LICENSE_HEADER_LINES = [
+    "# Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.",
+    "#",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\"). You may not",
+    "# use this file except in compliance with the License. A copy of the License is",
+    "# located at",
+    "#",
+    "#     http://www.apache.org/licenses/LICENSE-2.0",
+    "#",
+    "# or in the \"license\" file accompanying this file. This file is distributed on",
+    "# an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either",
+    "# express or implied. See the License for the specific language governing",
+    "# permissions and limitations under the License.",
+  ]
+
+  def test_files_have_license_header
+    test_dir = File.dirname(__FILE__)
+
+    files = Dir.glob("#{test_dir}/../lib/**/*.rb")
+    assert_operator files.size, :>, 1, "at least one file was loaded, otherwise the glob expression may be failing"
+
+    files.each do |filepath|
+      lines = File.read(filepath).split("\n")
+      assert_operator lines.size, :>, LICENSE_HEADER_LINES.size, "has license header"
+      LICENSE_HEADER_LINES.each_with_index do |license_line, i|
+        file_line = lines[i]
+        assert_equal license_line, file_line
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes #7

Adding Copyright license headers to all Twirp lib files and .go generator. And a test to make sure that new files added in the `lib` folder contain the license header.